### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     - run: npm run build-standalone:prod
     - name: Container image
       # Uses sha for added security since tags can be updated
-      uses: elgohr/Publish-Docker-Github-Action@b2f63259b466ca5a4be395c392546de447450334      
+      uses: elgohr/Publish-Docker-Github-Action@v5      
       with:
         name: ${{ github.repository }}
         dockerfile: Dockerfile


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore